### PR TITLE
Add sample Theia dockerfile for Zowe Explorer

### DIFF
--- a/.github/workflows/docker-reusable.yaml
+++ b/.github/workflows/docker-reusable.yaml
@@ -2,6 +2,9 @@ name: Build Sample Docker Image
 on:
   workflow_call:
     inputs:
+      build-args:
+        required: false
+        type: string
       name:
         required: true
         type: string
@@ -16,6 +19,9 @@ on:
         required: false
         default: false
         type: boolean
+      tags:
+        required: false
+        type: string
       timeout:
         required: false
         default: 15
@@ -29,6 +35,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set Default Tags
+        run: |
+          {
+            echo 'DEFAULT_TAGS<<EOF'
+            echo 'ghcr.io/zowe/zowe-sample-dockerfiles-${{ inputs.name }}:latest'
+            echo 'zowe-docker-snapshot.jfrog.io/ompzowe/zowe-sample-dockerfiles-${{ inputs.name }}:latest'
+            echo EOF
+          } >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -57,12 +72,11 @@ jobs:
         id:   build
         uses: docker/build-push-action@v4
         with:
+          build-args: ${{ inputs.build-args }}
           context: ${{ inputs.path }}
           push: ${{ inputs.push }}
           platforms: ${{ inputs.qemu && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          tags: |
-            ghcr.io/zowe/zowe-sample-dockerfiles-${{ inputs.name }}:latest
-            zowe-docker-snapshot.jfrog.io/ompzowe/zowe-sample-dockerfiles-${{ inputs.name }}:latest
-      
+          tags: ${{ inputs.tags || env.DEFAULT_TAGS }}
+
       - name: Image Digest
         run:  echo ${{ steps.build.outputs.digest }}

--- a/.github/workflows/docker-reusable.yaml
+++ b/.github/workflows/docker-reusable.yaml
@@ -72,7 +72,9 @@ jobs:
         id:   build
         uses: docker/build-push-action@v4
         with:
-          build-args: ${{ inputs.build-args }}
+          build-args: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+            ${{ inputs.build-args }}
           context: ${{ inputs.path }}
           push: ${{ inputs.push }}
           platforms: ${{ inputs.qemu && 'linux/amd64,linux/arm64' || 'linux/amd64' }}

--- a/.github/workflows/ze-theia-slim.yaml
+++ b/.github/workflows/ze-theia-slim.yaml
@@ -1,0 +1,51 @@
+name: Build ZE Theia Slim
+on:
+  push:
+    paths:
+      - ze/theia-slim/**
+      - .github/workflows/ze-theia-slim.yaml
+      - .github/workflows/docker-reusable.yaml
+  workflow_dispatch:
+    inputs:
+      theia-version:
+        description: "Specify Theia version (e.g., 1.37)"
+        default: "latest"
+        required: false
+        type: string
+      deploy:
+        description: "Push image to Docker registry"
+        default: false
+        required: false
+        type: boolean
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      docker-tags: ${{ steps.load-env.outputs.DOCKER_TAGS }}
+      theia-version: ${{ steps.load-env.outputs.THEIA_VERSION }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get Theia version
+        id: load-env
+        run: node ze/theia-slim/getTheiaVersion.js ${{ inputs.theia-version || 'next' }}
+
+  build-and-push:
+    needs: setup
+    uses: ./.github/workflows/docker-reusable.yaml
+    with:
+      build-args: |
+        GITHUB_TOKEN=${{ github.token }}
+        THEIA_VERSION=${{ needs.setup.outputs.theia-version }}
+      name: ze-theia-slim
+      path: ze/theia-slim
+      push: ${{ (github.event_name == 'workflow_dispatch' && inputs.deploy) || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == 'main') }}
+      qemu: ${{ (github.event_name == 'workflow_dispatch' && inputs.deploy) || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == 'main') }}
+      tags: ${{ needs.setup.outputs.docker-tags }}
+      timeout: 60
+    secrets: inherit

--- a/.github/workflows/ze-theia-slim.yaml
+++ b/.github/workflows/ze-theia-slim.yaml
@@ -35,12 +35,11 @@ jobs:
         id: load-env
         run: node ze/theia-slim/getTheiaVersion.js ${{ inputs.theia-version || 'next' }}
 
-  build-and-push:
+  build-and-deploy:
     needs: setup
     uses: ./.github/workflows/docker-reusable.yaml
     with:
       build-args: |
-        GITHUB_TOKEN=${{ github.token }}
         THEIA_VERSION=${{ needs.setup.outputs.theia-version }}
       name: ze-theia-slim
       path: ze/theia-slim

--- a/.github/workflows/ze-theia-slim.yaml
+++ b/.github/workflows/ze-theia-slim.yaml
@@ -44,6 +44,7 @@ jobs:
       name: ze-theia-slim
       path: ze/theia-slim
       push: ${{ (github.event_name == 'workflow_dispatch' && inputs.deploy) || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == 'main') }}
+      # Skip build for ARM64 unless we are deploying because it is slow
       qemu: ${{ (github.event_name == 'workflow_dispatch' && inputs.deploy) || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == 'main') }}
       tags: ${{ needs.setup.outputs.docker-tags }}
       timeout: 60

--- a/ze/README.md
+++ b/ze/README.md
@@ -1,0 +1,11 @@
+# Zowe Explorer Sample Dockerfiles
+
+## Theia Slim
+
+Provides a minimal installation of Theia in an Alpine docker container.
+The built container will expose Theia on port 3000 by default.
+Provides the ability to install Zowe Explorer in the container.
+
+<!-- ## Theia Full
+
+Coming soon! -->

--- a/ze/theia-slim/Dockerfile
+++ b/ze/theia-slim/Dockerfile
@@ -1,0 +1,44 @@
+ARG NODE_VERSION=lts
+ARG THEIA_VERSION=latest
+FROM node:${NODE_VERSION}-alpine
+RUN apk add --no-cache curl make pkgconfig gcc g++ python3 libx11-dev libxkbfile-dev libsecret-dev
+WORKDIR /home/theia
+ADD buildPackageJson.js ./buildPackageJson.js
+RUN node buildPackageJson.js ${THEIA_VERSION} > package.json
+ARG GITHUB_TOKEN
+RUN yarn --pure-lockfile && \
+    NODE_OPTIONS="--max_old_space_size=4096" yarn theia build && \
+    yarn theia download:plugins && \
+    yarn --production && \
+    yarn autoclean --init && \
+    echo *.ts >> .yarnclean && \
+    echo *.ts.map >> .yarnclean && \
+    echo *.spec.* >> .yarnclean && \
+    yarn autoclean --force && \
+    yarn cache clean
+# Uncomment the following lines to install Zowe Explorer in the container
+# ARG ZOWE_EXPLORER_VERSION=2.9.2
+# RUN cd /home/theia/plugins && \
+#   curl -fLOJ https://github.com/zowe/vscode-extension-for-zowe/releases/download/v${ZOWE_EXPLORER_VERSION}/vscode-extension-for-zowe-${ZOWE_EXPLORER_VERSION}.vsix && \
+#   curl -fLOJ https://github.com/zowe/vscode-extension-for-zowe/releases/download/v${ZOWE_EXPLORER_VERSION}/zowe-explorer-ftp-extension-${ZOWE_EXPLORER_VERSION}.vsix
+
+FROM node:${NODE_VERSION}-alpine
+# See : https://github.com/theia-ide/theia-apps/issues/34
+RUN addgroup theia && \
+    adduser -G theia -s /bin/sh -D theia;
+RUN chmod g+rw /home && \
+    mkdir -p /home/project && \
+    chown -R theia:theia /home/theia && \
+    chown -R theia:theia /home/project;
+RUN apk add --no-cache git openssh bash dbus gnome-keyring libcap libsecret
+ENV HOME /home/theia
+WORKDIR /home/theia
+COPY --from=0 --chown=theia:theia /home/theia /home/theia
+COPY ./entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+EXPOSE 3000
+ENV SHELL=/bin/bash \
+    THEIA_DEFAULT_PLUGINS=local-dir:/home/theia/plugins
+ENV USE_LOCAL_GIT true
+USER theia
+ENTRYPOINT [ "/entrypoint.sh", "node", "/home/theia/src-gen/backend/main.js", "/home/project", "--hostname=0.0.0.0" ]

--- a/ze/theia-slim/Dockerfile
+++ b/ze/theia-slim/Dockerfile
@@ -1,3 +1,11 @@
+# This program and the accompanying materials are made available and may be used, at your option, under either:
+# * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+# * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+# Copyright Contributors to the Zowe Project.
+
 ARG NODE_VERSION=lts
 ARG THEIA_VERSION=latest
 FROM node:${NODE_VERSION}-alpine

--- a/ze/theia-slim/README.md
+++ b/ze/theia-slim/README.md
@@ -1,0 +1,35 @@
+# Theia Docker Container
+
+Based on https://github.com/theia-ide/theia-apps/tree/master/theia-docker
+
+## How to Use
+
+To build the container, run `docker build .`
+
+The following runs Theia IDE on http://localhost:3000 with the current directory as a workspace. The option of `--init` is added to fix the [defunct process problem](https://github.com/theia-ide/theia-apps/issues/195).
+
+```bash
+# Linux, macOS, or PowerShell
+docker run -it --init -p 3000:3000 -v "$(pwd):/home/project:cached" <tag>
+
+# Windows (cmd.exe)
+docker run -it --init -p 3000:3000 -v "%cd%:/home/project:cached" <tag>
+```
+
+You can pass additional arguments to Theia after the image name, for example to enable debugging:
+
+```bash
+# Linux, macOS, or PowerShell
+docker run -it --init -p 3000:3000 --expose 9229 -p 9229:9229 -v "$(pwd):/home/project:cached" <tag> --inspect=0.0.0.0:9229
+
+# Windows (cmd.exe)
+docker run -it --init -p 3000:3000 --expose 9229 -p 9229:9229 -v "%cd%:/home/project:cached" <tag> --inspect=0.0.0.0:9229
+```
+
+## Tips and Tricks
+
+* To install a VS Code extension, copy the VSIX file into the container with the following command. Then run "Extensions: Install from VSIX" from the command palette in Theia and browse to the VSIX file.
+    ```bash
+    docker cp <path-to-vsix> ${containerId}:/home/theia/plugins
+    ```
+* To unlock the keyring so that Keytar can store secure credentials, pass these arguments to the `docker run` command: `--cap-add IPC_LOCK`

--- a/ze/theia-slim/buildPackageJson.js
+++ b/ze/theia-slim/buildPackageJson.js
@@ -1,0 +1,139 @@
+const theiaVersion = process.argv[2] || "latest";
+const packageJsonTemplate = `{
+    "private": true,
+    "theia": {
+        "frontend": {
+            "config": {
+                "applicationName": "Theia Sample",
+                "preferences": {
+                    "files.enableTrash": false
+                }
+            }
+        }
+    },
+    "dependencies": {
+        "@theia/callhierarchy": "latest",
+        "@theia/debug": "latest",
+        "@theia/editor-preview": "latest",
+        "@theia/file-search": "latest",
+        "@theia/getting-started": "latest",
+        "@theia/git": "latest",
+        "@theia/markers": "latest",
+        "@theia/messages": "latest",
+        "@theia/mini-browser": "latest",
+        "@theia/navigator": "latest",
+        "@theia/outline-view": "latest",
+        "@theia/plugin": "latest",
+        "@theia/plugin-ext": "latest",
+        "@theia/plugin-ext-vscode": "latest",
+        "@theia/preferences": "latest",
+        "@theia/preview": "latest",
+        "@theia/search-in-workspace": "latest",
+        "@theia/terminal": "latest",
+        "@theia/vsx-registry": "latest"
+    },
+    "devDependencies": {
+        "@theia/cli": "latest",
+        "@theia/electron": "latest"
+    },
+    "scripts": {
+        "preinstall": "node-gyp install"
+    },
+    "theiaPluginsDir": "plugins",
+    "theiaPlugins": {
+        "vscode-builtin-bat": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/bat-1.39.1-prel.vsix",
+        "vscode-builtin-clojure": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/clojure-1.39.1-prel.vsix",
+        "vscode-builtin-coffeescript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/coffeescript-1.39.1-prel.vsix",
+        "vscode-builtin-configuration-editing": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/configuration-editing-1.39.1-prel.vsix",
+        "vscode-builtin-cpp": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/cpp-1.39.1-prel.vsix",
+        "vscode-builtin-csharp": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/csharp-1.39.1-prel.vsix",
+        "vscode-builtin-css": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/css-1.39.1-prel.vsix",
+        "vscode-builtin-debug-auto-launch": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/debug-auto-launch-1.39.1-prel.vsix",
+        "vscode-builtin-docker": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/docker-1.39.1-prel.vsix",
+        "vscode-builtin-emmet": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/emmet-1.39.1-prel.vsix",
+        "vscode-builtin-fsharp": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/fsharp-1.39.1-prel.vsix",
+        "vscode-builtin-go": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/go-1.39.1-prel.vsix",
+        "vscode-builtin-groovy": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/groovy-1.39.1-prel.vsix",
+        "vscode-builtin-grunt": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/grunt-1.39.1-prel.vsix",
+        "vscode-builtin-gulp": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/gulp-1.39.1-prel.vsix",
+        "vscode-builtin-handlebars": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/handlebars-1.39.1-prel.vsix",
+        "vscode-builtin-hlsl": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/hlsl-1.39.1-prel.vsix",
+        "vscode-builtin-html": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/html-1.39.1-prel.vsix",
+        "vscode-builtin-html-language-features": "https://open-vsx.org/api/vscode/html-language-features/1.49.0/file/vscode.html-language-features-1.49.0.vsix",
+        "vscode-builtin-ini": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/ini-1.39.1-prel.vsix",
+        "vscode-builtin-jake": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/jake-1.39.1-prel.vsix",
+        "vscode-builtin-java": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/java-1.39.1-prel.vsix",
+        "vscode-builtin-javascript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/javascript-1.39.1-prel.vsix",
+        "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
+        "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
+        "vscode-builtin-less": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/less-1.39.1-prel.vsix",
+        "vscode-builtin-log": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/log-1.39.1-prel.vsix",
+        "vscode-builtin-lua": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/lua-1.39.1-prel.vsix",
+        "vscode-builtin-make": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/make-1.39.1-prel.vsix",
+        "vscode-builtin-markdown": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/markdown-1.39.1-prel.vsix",
+        "vscode-builtin-merge-conflicts": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/merge-conflict-1.39.1-prel.vsix",
+        "vscode-builtin-npm": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/npm-1.39.1-prel.vsix",
+        "vscode-builtin-node-debug": "https://github.com/theia-ide/vscode-node-debug/releases/download/v1.35.3/node-debug-1.35.3.vsix",
+        "vscode-builtin-node-debug2": "https://github.com/theia-ide/vscode-node-debug2/releases/download/v1.33.0/node-debug2-1.33.0.vsix",
+        "vscode-builtin-objective-c": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/objective-c-1.39.1-prel.vsix",
+        "vscode-builtin-perl": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/perl-1.39.1-prel.vsix",
+        "vscode-builtin-powershell": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/powershell-1.39.1-prel.vsix",
+        "vscode-builtin-pug": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/pug-1.39.1-prel.vsix",
+        "vscode-builtin-python": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/python-1.39.1-prel.vsix",
+        "vscode-builtin-r": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/r-1.39.1-prel.vsix",
+        "vscode-builtin-razor": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/razor-1.39.1-prel.vsix",
+        "vscode-builtin-ruby": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/ruby-1.39.1-prel.vsix",
+        "vscode-builtin-rust": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/rust-1.39.1-prel.vsix",
+        "vscode-builtin-scss": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/scss-1.39.1-prel.vsix",
+        "vscode-builtin-shaderlab": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/shaderlab-1.39.1-prel.vsix",
+        "vscode-builtin-shellscript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/shellscript-1.39.1-prel.vsix",
+        "vscode-builtin-sql": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/sql-1.39.1-prel.vsix",
+        "vscode-builtin-swift": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/swift-1.39.1-prel.vsix",
+        "vscode-builtin-theme-abyss": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/theme-abyss-1.39.1-prel.vsix",
+        "vscode-builtin-theme-defaults": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/theme-defaults-1.39.1-prel.vsix",
+        "vscode-builtin-theme-kimbie-dark": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/theme-kimbie-dark-1.39.1-prel.vsix",
+        "vscode-builtin-theme-monokai": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/theme-monokai-1.39.1-prel.vsix",
+        "vscode-builtin-theme-dimmed": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/theme-monokai-dimmed-1.39.1-prel.vsix",
+        "vscode-builtin-theme-quietlight": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/theme-quietlight-1.39.1-prel.vsix",
+        "vscode-builtin-theme-red": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/theme-red-1.39.1-prel.vsix",
+        "vscode-builtin-theme-solarized-dark": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/theme-solarized-dark-1.39.1-prel.vsix",
+        "vscode-builtin-theme-tomorrow-night-blue": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/theme-tomorrow-night-blue-1.39.1-prel.vsix",
+        "vscode-builtin-typescript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/typescript-1.39.1-prel.vsix",
+        "vscode-builtin-typescript-language-features": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/typescript-language-features-1.39.1-prel.vsix",
+        "vscode-builtin-vb": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/vb-1.39.1-prel.vsix",
+        "vscode-builtin-icon-theme-seti": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/vscode-theme-seti-1.39.1-prel.vsix",
+        "vscode-builtin-xml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/xml-1.39.1-prel.vsix",
+        "vscode-builtin-yaml": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/yaml-1.39.1-prel.vsix",
+        "vscode-editorconfig": "https://github.com/theia-ide/editorconfig-vscode/releases/download/v0.14.4/EditorConfig-0.14.4.vsix",
+        "vscode-eslint": "https://github.com/theia-ide/vscode-eslint/releases/download/release%2F2.0.15/vscode-eslint-2.0.15.vsix"
+    },
+    "theiaPluginsExcludeIds": [
+        "ms-vscode.js-debug-companion",
+        "vscode.extension-editing",
+        "vscode.git",
+        "vscode.git-ui",
+        "vscode.github",
+        "vscode.github-authentication",
+        "vscode.microsoft-authentication"
+    ]
+}`;
+
+async function getTheiaPlugins(theiaVersion) {
+    const theiaGitRef = theiaVersion !== "latest" ? `v${theiaVersion}` : "master";
+    const response = await fetch(`https://raw.githubusercontent.com/eclipse-theia/theia/${theiaGitRef}/package.json`);
+    const theiaPlugins = (await response.json()).theiaPlugins;
+    const builtinExtensionPack = "eclipse-theia.builtin-extension-pack";
+    return { [builtinExtensionPack]: theiaPlugins[builtinExtensionPack] };
+}
+
+(async () => {
+    const packageJson = JSON.parse(packageJsonTemplate);
+    for (const k of Object.keys(packageJson.dependencies)) {
+        packageJson.dependencies[k] = theiaVersion;
+    }
+    for (const k of Object.keys(packageJson.devDependencies)) {
+        packageJson.devDependencies[k] = theiaVersion;
+    }
+    packageJson.theiaPlugins = await getTheiaPlugins(theiaVersion);
+    console.log(JSON.stringify(packageJson, null, 4));
+})();

--- a/ze/theia-slim/buildPackageJson.js
+++ b/ze/theia-slim/buildPackageJson.js
@@ -1,3 +1,13 @@
+/**
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
 const theiaVersion = process.argv[2] || "latest";
 const packageJsonTemplate = `{
     "private": true,

--- a/ze/theia-slim/entrypoint.sh
+++ b/ze/theia-slim/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Check if container has IPC_LOCK capability
+if capsh --print | grep -q cap_ipc_lock; then
+    # Launch dbus for gnome-keyring
+    if test -z "$DBUS_SESSION_BUS_ADDRESS" ; then
+        exec dbus-run-session -- $0 "$@"
+    fi
+
+    # Unlock gnome-keyring to store credentials
+    echo "root" | gnome-keyring-daemon -r -d --unlock
+fi
+
+exec "$@"

--- a/ze/theia-slim/entrypoint.sh
+++ b/ze/theia-slim/entrypoint.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# This program and the accompanying materials are made available and may be used, at your option, under either:
+# * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+# * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+# Copyright Contributors to the Zowe Project.
+
 # Check if container has IPC_LOCK capability
 if capsh --print | grep -q cap_ipc_lock; then
     # Launch dbus for gnome-keyring

--- a/ze/theia-slim/getTheiaVersion.js
+++ b/ze/theia-slim/getTheiaVersion.js
@@ -1,3 +1,13 @@
+/**
+ * This program and the accompanying materials are made available and may be used, at your option, under either:
+ * * Eclipse Public License v2.0, available at https://www.eclipse.org/legal/epl-v20.html, OR
+ * * Apache License, version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
 const fs = require("fs");
 const outputPath = process.env.GITHUB_OUTPUT || process.stdout.fd;
 

--- a/ze/theia-slim/getTheiaVersion.js
+++ b/ze/theia-slim/getTheiaVersion.js
@@ -1,0 +1,34 @@
+const fs = require("fs");
+const outputPath = process.env.GITHUB_OUTPUT || process.stdout.fd;
+
+function expandImageTag(shortTag) {
+    return [
+        `ghcr.io/zowe/zowe-sample-dockerfiles-ze-theia-slim:${shortTag}`,
+        `zowe-docker-snapshot.jfrog.io/ompzowe/zowe-sample-dockerfiles-ze-theia-slim:${shortTag}`
+    ];
+}
+
+async function getTheiaReleases() {
+    const response = await fetch("https://api.github.com/repos/eclipse-theia/theia/releases");
+    return await response.json();
+}
+
+(async () => {
+    const dockerTags = [];
+    let theiaVersion;
+    if (process.argv[2] == "next") {
+        theiaVersion = "latest";
+        dockerTags.push(...expandImageTag("next"));
+    } else if (process.argv[2] == null || process.argv[2] == "latest") {
+        const release = (await getTheiaReleases()).find(obj => obj.body.includes("community release"));
+        theiaVersion = release.tag_name.slice(1);
+        dockerTags.push(...expandImageTag("latest"),
+            ...expandImageTag(theiaVersion.slice(0, theiaVersion.lastIndexOf("."))));
+    } else {
+        const release = (await getTheiaReleases()).find(obj => obj.tag_name.startsWith(`v${process.argv[2]}`));
+        theiaVersion = release.tag_name.slice(1);
+        dockerTags.push(...expandImageTag(theiaVersion.slice(0, theiaVersion.lastIndexOf("."))));
+    }
+    fs.appendFileSync(outputPath, "DOCKER_TAGS<<EOF\n" + dockerTags.join("\n") + "\nEOF\n");
+    fs.appendFileSync(outputPath, `THEIA_VERSION=${theiaVersion}\n`);
+})();

--- a/ze/theia-slim/getTheiaVersion.js
+++ b/ze/theia-slim/getTheiaVersion.js
@@ -26,10 +26,10 @@ async function getTheiaReleases() {
 (async () => {
     const dockerTags = [];
     let theiaVersion;
-    if (process.argv[2] == "next") {
+    if (process.argv[2] === "next") {
         theiaVersion = "latest";
         dockerTags.push(...expandImageTag("next"));
-    } else if (process.argv[2] == null || process.argv[2] == "latest") {
+    } else if (process.argv[2] == null || process.argv[2] === "latest") {
         const release = (await getTheiaReleases()).find(obj => obj.body.includes("community release"));
         theiaVersion = release.tag_name.slice(1);
         dockerTags.push(...expandImageTag("latest"),

--- a/ze/theia-slim/getTheiaVersion.js
+++ b/ze/theia-slim/getTheiaVersion.js
@@ -26,16 +26,20 @@ async function getTheiaReleases() {
 (async () => {
     const dockerTags = [];
     let theiaVersion;
-    if (process.argv[2] === "next") {
-        theiaVersion = "latest";
-        dockerTags.push(...expandImageTag("next"));
-    } else if (process.argv[2] == null || process.argv[2] === "latest") {
+    if (process.argv[2] == null || process.argv[2] === "latest") {
+        // "latest" tag (default) = latest community release of Theia
         const release = (await getTheiaReleases()).find(obj => obj.body.includes("community release"));
         theiaVersion = release.tag_name.slice(1);
         dockerTags.push(...expandImageTag("latest"),
             ...expandImageTag(theiaVersion.slice(0, theiaVersion.lastIndexOf("."))));
+    } else if (process.argv[2] === "next") {
+        // "next" tag = latest version of Theia on master branch
+        theiaVersion = "latest";
+        dockerTags.push(...expandImageTag("next"));
     } else {
-        const release = (await getTheiaReleases()).find(obj => obj.tag_name.startsWith(`v${process.argv[2]}`));
+        // "1.XX" tag = older community release of Theia
+        const release = (await getTheiaReleases()).find(obj => obj.body.includes("community release") &&
+            obj.tag_name.startsWith(`v${process.argv[2]}`));
         theiaVersion = release.tag_name.slice(1);
         dockerTags.push(...expandImageTag(theiaVersion.slice(0, theiaVersion.lastIndexOf("."))));
     }


### PR DESCRIPTION
Migrates the [t1m0thyj/theia-docker](https://github.com/t1m0thyj/theia-docker) repo 🙂 

I plan to publish a new tag of the image every 3 months when there is a new Theia community (LTS) release.
There is also a "next" tag published weekly for the latest release.