### PR TITLE
I don't know why this fixes it but it does

### DIFF
--- a/ze/theia-slim/Dockerfile
+++ b/ze/theia-slim/Dockerfile
@@ -12,9 +12,12 @@ FROM node:${NODE_VERSION}-alpine
 RUN apk add --no-cache curl make pkgconfig gcc g++ python3 libx11-dev libxkbfile-dev libsecret-dev
 WORKDIR /home/theia
 ADD buildPackageJson.js ./buildPackageJson.js
-RUN node buildPackageJson.js ${THEIA_VERSION} > package.json
+RUN node --experimental-fetch buildPackageJson.js ${THEIA_VERSION} > package.json
 ARG GITHUB_TOKEN
-RUN yarn --pure-lockfile && \
+
+# First yarn generates the lockfile, second one installs things. Don't ask why this is necessary, I don't know either -_-
+RUN yarn && \ 
+    yarn && \
     NODE_OPTIONS="--max_old_space_size=4096" yarn theia build && \
     yarn theia download:plugins && \
     yarn --production && \
@@ -23,7 +26,8 @@ RUN yarn --pure-lockfile && \
     echo *.ts.map >> .yarnclean && \
     echo *.spec.* >> .yarnclean && \
     yarn autoclean --force && \
-    yarn cache clean
+    yarn cache clean && \
+    rm -f yarn.lock
 # Uncomment the following lines to install Zowe Explorer in the container
 # ARG ZOWE_EXPLORER_VERSION=2.9.2
 # RUN cd /home/theia/plugins && \


### PR DESCRIPTION
I don't know why, but with Node 18, the first yarn command only generates the lock file, and the second downloads and installs everything. The `--pure-lockfile` argument no longer appears to work. This is intended to be a temporary fix until @t1m0thyj can investigate further.