### PR TITLE
Install chromium

### DIFF
--- a/ze/theia-slim/Dockerfile
+++ b/ze/theia-slim/Dockerfile
@@ -9,7 +9,7 @@
 ARG NODE_VERSION=lts
 ARG THEIA_VERSION=latest
 FROM node:${NODE_VERSION}-alpine
-RUN apk add --no-cache curl make pkgconfig gcc g++ python3 libx11-dev libxkbfile-dev libsecret-dev
+RUN apk add --no-cache curl make pkgconfig gcc g++ python3 libx11-dev libxkbfile-dev libsecret-dev chromium
 WORKDIR /home/theia
 ADD buildPackageJson.js ./buildPackageJson.js
 RUN node --experimental-fetch buildPackageJson.js ${THEIA_VERSION} > package.json


### PR DESCRIPTION
Puppeteer requires it, but removed the logic to install it on ARM64 if it is missing. So now we do it manually.