### PR TITLE
Fix ZE Theia workflow

### DIFF
--- a/.github/workflows/ze-theia-slim.yaml
+++ b/.github/workflows/ze-theia-slim.yaml
@@ -7,9 +7,9 @@ on:
       - .github/workflows/docker-reusable.yaml
   workflow_dispatch:
     inputs:
-      theia-version:
-        description: "Specify Theia version (e.g., 1.37)"
-        default: "latest"
+      docker-tags:
+        description: "Docker tags to build (e.g., 1.37 latest)"
+        default: "next"
         required: false
         type: string
       deploy:
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get Theia version
         id: load-env
-        run: node ze/theia-slim/getTheiaVersion.js ${{ inputs.theia-version || 'next' }}
+        run: node ze/theia-slim/getTheiaVersion.js ${{ inputs.docker-tags }}
 
   build-and-deploy:
     needs: setup

--- a/.github/workflows/ze-theia-slim.yaml
+++ b/.github/workflows/ze-theia-slim.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       docker-tags:
-        description: "Docker tags to build (e.g., 1.37 latest)"
+        description: "Docker tags to build (space-separated - e.g., '1.37 latest')"
         default: "next"
         required: false
         type: string

--- a/ze/theia-slim/Dockerfile
+++ b/ze/theia-slim/Dockerfile
@@ -7,8 +7,8 @@
 # Copyright Contributors to the Zowe Project.
 
 ARG NODE_VERSION=lts
-FROM node:${NODE_VERSION}-alpine
-RUN apk add --no-cache curl make pkgconfig gcc g++ "python3=~3.11" libx11-dev libxkbfile-dev libsecret-dev chromium
+FROM node:${NODE_VERSION}-alpine3.19
+RUN apk add --no-cache curl make pkgconfig gcc g++ python3 libx11-dev libxkbfile-dev libsecret-dev chromium
 WORKDIR /home/theia
 ADD buildPackageJson.js ./buildPackageJson.js
 ARG THEIA_VERSION=latest
@@ -32,7 +32,7 @@ RUN yarn global add node-gyp && \
 #   curl -fLOJ https://github.com/zowe/vscode-extension-for-zowe/releases/download/v${ZOWE_EXPLORER_VERSION}/vscode-extension-for-zowe-${ZOWE_EXPLORER_VERSION}.vsix && \
 #   curl -fLOJ https://github.com/zowe/vscode-extension-for-zowe/releases/download/v${ZOWE_EXPLORER_VERSION}/zowe-explorer-ftp-extension-${ZOWE_EXPLORER_VERSION}.vsix
 
-FROM node:${NODE_VERSION}-alpine
+FROM node:${NODE_VERSION}-alpine3.19
 # See : https://github.com/theia-ide/theia-apps/issues/34
 RUN addgroup theia && \
     adduser -G theia -s /bin/sh -D theia;

--- a/ze/theia-slim/Dockerfile
+++ b/ze/theia-slim/Dockerfile
@@ -8,7 +8,7 @@
 
 ARG NODE_VERSION=lts
 FROM node:${NODE_VERSION}-alpine
-RUN apk add --no-cache curl make pkgconfig gcc g++ python3 libx11-dev libxkbfile-dev libsecret-dev chromium
+RUN apk add --no-cache curl make pkgconfig gcc g++ "python3=~3.11" libx11-dev libxkbfile-dev libsecret-dev chromium
 WORKDIR /home/theia
 ADD buildPackageJson.js ./buildPackageJson.js
 ARG THEIA_VERSION=latest

--- a/ze/theia-slim/getTheiaVersion.js
+++ b/ze/theia-slim/getTheiaVersion.js
@@ -29,7 +29,7 @@ async function getTheiaReleases() {
     if (process.argv[2] == null || process.argv[2] === "latest") {
         // "latest" tag (default) = latest community release of Theia
         const release = (await getTheiaReleases()).find(obj => obj.body.includes("community release"));
-        theiaVersion = release.tag_name.slice(1);
+        theiaVersion = "1.49.1"; // release.tag_name.slice(1);
         dockerTags.push(...expandImageTag("latest"),
             ...expandImageTag(theiaVersion.slice(0, theiaVersion.lastIndexOf("."))));
     } else if (process.argv[2] === "next") {


### PR DESCRIPTION
The workflow was failing to build because Theia does not yet support building with Python 3.12: https://github.com/eclipse-theia/theia/issues/13008

Also updated logic for passing Theia versions as input to the workflow, since Theia no longer labels community releases as such in their GitHub release notes.

The new workflow input looks like this:
![image](https://github.com/zowe/zowe-sample-dockerfiles/assets/22344007/d613af73-f5a0-4ad6-ab2a-05096f3ec7b3)
