### PR TITLE
Fix 429 rate limit error in weekly Theia build

### DIFF
--- a/.github/workflows/docker-reusable.yaml
+++ b/.github/workflows/docker-reusable.yaml
@@ -72,12 +72,12 @@ jobs:
         id:   build
         uses: docker/build-push-action@v5
         with:
-          build-args: |
-            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-            ${{ inputs.build-args }}
+          build-args: ${{ inputs.build-args }}
           context: ${{ inputs.path }}
           push: ${{ inputs.push }}
           platforms: ${{ inputs.qemu && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          secret-envs: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ inputs.tags || env.DEFAULT_TAGS }}
 
       - name: Image Digest

--- a/.github/workflows/docker-reusable.yaml
+++ b/.github/workflows/docker-reusable.yaml
@@ -76,8 +76,7 @@ jobs:
           context: ${{ inputs.path }}
           push: ${{ inputs.push }}
           platforms: ${{ inputs.qemu && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          secret-envs: |
-            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          secrets: github_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ inputs.tags || env.DEFAULT_TAGS }}
 
       - name: Image Digest

--- a/ze/theia-slim/Dockerfile
+++ b/ze/theia-slim/Dockerfile
@@ -13,11 +13,10 @@ WORKDIR /home/theia
 ADD buildPackageJson.js ./buildPackageJson.js
 ARG THEIA_VERSION=latest
 RUN echo "$(node buildPackageJson.js ${THEIA_VERSION})" > package.json
-ARG GITHUB_TOKEN
 RUN yarn global add node-gyp && \
     yarn --pure-lockfile && \
     NODE_OPTIONS="--max_old_space_size=4096" yarn theia build && \
-    yarn theia download:plugins && \
+    yarn theia download:plugins --rate-limit=15 --parallel=false && \
     yarn --production && \
     yarn autoclean --init && \
     echo *.ts >> .yarnclean && \

--- a/ze/theia-slim/README.md
+++ b/ze/theia-slim/README.md
@@ -6,8 +6,6 @@ Based on https://github.com/theia-ide/theia-apps/tree/master/theia-docker
 
 To build the container, run `docker build .`
 
-**Note:** You may need to provide a GITHUB_TOKEN as a build argument with `repo` access
-
 The following runs Theia IDE on http://localhost:3000 with the current directory as a workspace. The option of `--init` is added to fix the [defunct process problem](https://github.com/theia-ide/theia-apps/issues/195).
 
 ```bash


### PR DESCRIPTION
* Provide the GitHub token to Dockerfile more securely to prevent the following warning:
    `SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ARG "GITHUB_TOKEN")`
* Pass options to `yarn theia download:plugins` command to rate limit it so that token isn't needed 😋 
    Inspired by https://github.com/eclipse-theia/theia-blueprint/blob/v1.47.0/package.json#L42